### PR TITLE
feat(manifest-update): støtt konfigurerbart K8S_NAMESPACE fra .env

### DIFF
--- a/.github/action/manifest-update/action.yml
+++ b/.github/action/manifest-update/action.yml
@@ -13,6 +13,10 @@ inputs:
   manifest-installation-id:
     description: 'GitHub App Installation ID for Manifest'
     required: true
+  k8s-namespace:
+    description: 'Kubernetes namespace for manifest overlay (defaults to nbno)'
+    required: false
+    default: 'nbno'
 
 runs:
     using: "composite"
@@ -53,11 +57,11 @@ runs:
           kustomize edit set image ${{ env.DOCKER_IMAGE }}:${{ inputs.release-version }}
           cd ../../../../..
           
-      - name: Update manifest nbno files
+      - name: Update manifest namespace files
         shell: bash
         run: |
-          echo "Updating manifest nbno for service ${{ env.SERVICE_NAME }} docker-image: ${{ env.DOCKER_IMAGE }} with tag: ${{ inputs.release-version }} "
-          cd nbno-k8s-manifest/${{ env.SERVICE_NAME }}/overlays/k8s.stage.nb.no/nbno
+          echo "Updating manifest ${{ inputs.k8s-namespace }} for service ${{ env.SERVICE_NAME }} docker-image: ${{ env.DOCKER_IMAGE }} with tag: ${{ inputs.release-version }} "
+          cd nbno-k8s-manifest/${{ env.SERVICE_NAME }}/overlays/k8s.stage.nb.no/${{ inputs.k8s-namespace }}
           kustomize edit set image ${{ env.DOCKER_IMAGE }}:${{ inputs.release-version }}
           cd ../../../../..
 

--- a/.github/workflows/build-mvn-spring-app-v3.4.yaml
+++ b/.github/workflows/build-mvn-spring-app-v3.4.yaml
@@ -327,6 +327,7 @@ jobs:
           manifest-privatekey: ${{ env.MANIFEST_PRIVATEKEY }}
           manifest-installation-id: ${{ env.MANIFEST_INSTALLATION_ID }}
           release-version: ${{ needs.build-publish-app.outputs.build-tag }}
+          k8s-namespace: ${{ env.K8S_NAMESPACE || 'nbno' }}
 
   run-nbno-api-test:
     name: Trigger Run nbno-api-test


### PR DESCRIPTION
## Endring
Gjør K8S namespace konfigurerbart i manifest-update actionen via `K8S_NAMESPACE` i `.env`-filen.
### Hva er endret
- **`manifest-update/action.yml`**: Ny input `k8s-namespace` (default: `nbno`). Steget som oppdaterer manifest-filer bruker nå inputen i stien i stedet for hardkodet `nbno`.
- **`build-mvn-spring-app-v3.4.yaml`**: Sender `k8s-namespace: ${{ env.K8S_NAMESPACE || 'nbno' }}` til manifest-update actionen.
### Bakoverkompatibilitet
Fullt bakoverkompatibelt — uten `K8S_NAMESPACE` i `.env` brukes default `nbno` som før.
### Verifisering
- Repo uten `K8S_NAMESPACE` i `.env` → bruker `nbno` (uendret oppførsel)
- Repo med `K8S_NAMESPACE=mitt-namespace` → bruker `mitt-namespace` i overlay-stien